### PR TITLE
Export dates in YYYY-MM-DD string format

### DIFF
--- a/db.js
+++ b/db.js
@@ -1,5 +1,9 @@
 const pgp = require('pg-promise')()
 
+// https://github.com/brianc/node-pg-types/issues/50
+const DATE_OID = 1082
+pgp.pg.types.setTypeParser(DATE_OID, v => v)
+
 const queryFiles = new Map()
 
 function sql (filename) {


### PR DESCRIPTION
A JS Date (`new Date`) instance is an object wrapper for timestamps (date-time), not for date only values (DATE in SQL).

Wrapping DATE values in JS Date objects has at least two issues:

1. Pg parser, for some reason will parse the DATE value to a JS Date applying the local timezone.
This is an issue specially in local/dev environement, where local TZ is usually not UTC.

2. Stringified JS Date will be converted as a string in ISO format, with full date+time information, giving impression it is a point in time, not a wall date.