### PR TITLE
Simpler Error Handling

### DIFF
--- a/error.js
+++ b/error.js
@@ -23,6 +23,7 @@ function assertValidDbErrorMappingKey (key) {
 
 class GenericError extends NestedError {
   constructor (ec, cause, status) {
+    assertValidErrorConst(ec)
     super(ec, cause)
     this.error = ec
     this.code = ec
@@ -35,7 +36,6 @@ class HttpError extends GenericError {}
 class ValidationError extends GenericError {}
 
 function error (ec, cause, status) {
-  if (!inProduction) assertValidErrorConst(ec)
   if (ec.startsWith('http.')) return new HttpError(ec, cause, status || _.get(errors, ec) || 500)
   if (ec.startsWith('db.')) return new DatabaseError(ec, cause, status || 500)
   if (ec.endsWith('.not_found')) return new GenericError(ec, cause, status || 404)

--- a/error.js
+++ b/error.js
@@ -43,6 +43,9 @@ function error (ec, cause, status) {
 }
 
 error.db = (mapping = {}) => {
+  if (mapping instanceof DatabaseError) {
+    throw mapping
+  }
   if (mapping instanceof Error) {
     throw error('db.internal', mapping)
   }
@@ -53,6 +56,10 @@ error.db = (mapping = {}) => {
   }
 
   return cause => {
+    if (cause instanceof DatabaseError) {
+      throw cause
+    }
+
     const key = cause instanceof QueryResultError
       ? queryResultErrorName[cause.code]
       : cause.constraint

--- a/error.js
+++ b/error.js
@@ -48,7 +48,8 @@ error.db = (mapping = {}) => {
   }
 
   if (!inProduction) {
-    _.keys(mapping).filter(_.isString).forEach(assertValidDbErrorMappingKey)
+    _.keys(mapping).forEach(assertValidDbErrorMappingKey)
+    _.values(mapping).filter(_.isString).forEach(assertValidErrorConst)
   }
 
   return cause => {

--- a/error.toml
+++ b/error.toml
@@ -9,6 +9,7 @@ connection = 1000
 read = 1000
 write = 1001
 delete = 1002
+internal = 1003
 
 [user]
 password_wrong = 2001

--- a/error.toml
+++ b/error.toml
@@ -2,6 +2,7 @@
 bad_request = 400
 unauthorized = 401
 not_found = 404
+duplicate = 409
 internal = 500
 
 [db]

--- a/middleware/error.js
+++ b/middleware/error.js
@@ -2,24 +2,16 @@ const _ = require('lodash')
 
 const error = require('error')
 
+const httpCodeByStatus = _.invert(error.errors.http)
+
 function wrap (err) {
   if (err instanceof error.GenericError) {
     return err
   }
 
-  if (err.status === 400) {
-    return error.http('http.bad_request', 400)(err, true)
-  }
+  const httpCode = (err.status && httpCodeByStatus[err.status]) || 'internal'
 
-  if (err.status === 401) {
-    return error.http('http.unauthorized', 401)(err, true)
-  }
-
-  if (err.status === 404) {
-    return error.http('http.not_found', 404)(err, true)
-  }
-
-  return error.http('http.internal')(err, true)
+  return error(`http.${httpCode}`, err)
 }
 
 function status (err) {
@@ -29,7 +21,7 @@ function status (err) {
 function format (err) {
   if (err instanceof error.ValidationError) {
     return {
-      status: false,
+      // status: false,
       code: err.code,
       error: err.error,
       errorv: {

--- a/middleware/error.js
+++ b/middleware/error.js
@@ -31,7 +31,6 @@ function format (err) {
 
   if (err instanceof error.GenericError) {
     return {
-      status: false,
       code: err.code,
       error: err.error,
       errorv: process.env.NODE_ENV === 'development' ? err.nested : null,

--- a/middleware/error.js
+++ b/middleware/error.js
@@ -21,7 +21,6 @@ function status (err) {
 function format (err) {
   if (err instanceof error.ValidationError) {
     return {
-      // status: false,
       code: err.code,
       error: err.error,
       errorv: {

--- a/repo/passwordToken.js
+++ b/repo/passwordToken.js
@@ -10,8 +10,7 @@ async function create (userId) {
   await remove(userId)
   return db.one('INSERT INTO password_token (user_id, token) VALUES ($1, $2) RETURNING token', [userId, token])
   .get('token')
-  .catch({ constraint: 'password_token_pkey' }, error.db('db.write'))
-  .catch(error.db('db.write'))
+  .catch(error.db)
 }
 
 async function createById (userId) {
@@ -25,7 +24,7 @@ async function createByEmail (email) {
 }
 
 async function remove (userId) {
-  return db.none('DELETE FROM password_token WHERE user_id = $1', [userId])
+  return db.none('DELETE FROM password_token WHERE user_id = $1', [userId]).catch(error.db)
 }
 
 async function get (token) {
@@ -36,8 +35,8 @@ async function get (token) {
       token = $1
       AND created_at > now() - interval '$2 hour'
   `, [token, _.toInteger(process.env.PASSWORD_TOKEN_DURATION)])
+  .catch(error.db({ noData: 'user.password_token_invalid' }))
   .get('user_id')
-  .catch(error.QueryResultError, error('user.password_token_invalid'))
 }
 
 module.exports = {

--- a/repo/user.js
+++ b/repo/user.js
@@ -62,10 +62,10 @@ async function create (email, password) {
       id: user.id,
       role: konst.roleUser.none,
     })
+    .catch(error.db)
 
     return user
   })
-  .catch(error.db)
 }
 
 async function updatePassword (id, password) {

--- a/route/user.test.js
+++ b/route/user.test.js
@@ -78,7 +78,7 @@ test.api('signin not existing', async function (t, request) {
   const r = await request.post('/signin').send({
     email: 'not.existent@example.com',
   })
-  t.is(r.status, 400, 'fail')
+  t.is(r.status, 404, 'not found')
   t.ok(r.body.error, 'with error')
 
   mailer.passwordlessLink = passwordlessLink
@@ -283,7 +283,7 @@ test.api('password token nonexistant', async function (t, request) {
   const r = await request.post('/recoverPassword').send({
     email: 'nonexistant@example.com',
   })
-  t.is(r.status, 400, 'bad request')
+  t.is(r.status, 404, 'bad request')
   t.is(r.body.error, 'user.not_found', 'error code')
 })
 


### PR DESCRIPTION
## Error Creation

The `error()` function is now intended as the primary error factory with improved defaults for common error codes to make usage more simpler/concise and errors more consistent.

```JS
error('user.not_found') // --> GenericError 404 (error code ending with ".not_found")

error('http.unauthorized') // --> HttpError 401 (http.* values are default statuses)

error('some.error') // --> GenericError 400

error('some.other_error', nestedErrorOrNull, 403) // --> GenericError 403
```

## DB Error Handling

The `error.db` function is intended as replacement for all DB query error handling, with some important additional benefits:

- Single `.catch(...)`:
  - Makes error handling easier to reason about
  - Removes the need for always passing-thro already wrapped errors in subsequent catches (old `error()`, `error.http()`, `error.db()` would pass-thro `GenericError`s, making use of those probably unexpected if used in other places...)
- Does not relay on non-standard Bluebird `.catch(filter, handler)` (see [#10](https://github.com/blazing-edge-labs/api-skeleton/issues/10)) 


```JS
return db.one(`SELECT * FROM "user" WHERE "email" = $1`, [email])
.catch(error.db({
  noData: 'user.not_found',
}))

await db.query(`
  UPDATE "user"
  SET "email" = $2
  WHERE "id" = $1
`, [id, email])
.catch(error.db({
  user_email_key: 'user.duplicate',
}))

await db.query('DELETE FROM password_token WHERE user_id = $1', [userId])
.catch(error.db) // ensure DB errors are wrapped in a DatabaseError
```

Please, let me know if you have any concern or objections.
