### PR TITLE
Wrapping PGP

### DIFF
--- a/db.js
+++ b/db.js
@@ -1,8 +1,28 @@
-const pgp = require('pg-promise')()
+const pgp = require('pg-promise')({
+  // error (_err, e) { console.log('------\n', e.query) },
+  // query (e) { console.log('------\n', e.query) },
+})
+
+const error = require('error')
+const { wrapDatabase } = require('utils/pgp-wrappers')
+
+/// PG stuff
 
 // https://github.com/brianc/node-pg-types/issues/50
 const DATE_OID = 1082
 pgp.pg.types.setTypeParser(DATE_OID, v => v)
+
+/// DB stuff
+
+const pgpDB = pgp(process.env.DATABASE_URL)
+
+const db = wrapDatabase(pgpDB, {
+  queryErrorHandler: e => {
+    throw error('db.query', e)
+  },
+})
+
+/// sql(file)
 
 const queryFiles = new Map()
 
@@ -18,7 +38,8 @@ function sql (filename) {
 }
 
 module.exports = {
-  db: pgp(process.env.DATABASE_URL),
+  db,
+  pgpDB,
   helper: pgp.helpers,
   pgp,
   sql,

--- a/db.test.js
+++ b/db.test.js
@@ -1,0 +1,48 @@
+const test = require('test')
+const { db } = require('db')
+const { delay } = require('utils/promise')
+
+test('parallel sub transactions', async t => {
+  await db.query(`
+    DROP TABLE IF EXISTS test_tx;
+    CREATE TABLE test_tx (
+      id SERIAL PRIMARY KEY,
+      "desc" TEXT
+    )
+  `)
+
+  async function runQueries (tx) {
+    for (const x of [1, 2, 3, 4, 5]) {
+      await tx.query('INSERT INTO test_tx ("desc") VALUES ($1)', [`query ${x}`])
+      await delay(100)
+    }
+  }
+
+  async function runSubTx (tx) {
+    await tx.tx(async tx => {
+      await tx.query('INSERT INTO test_tx ("desc") VALUES (\'back-rolled\')')
+      await delay(2.5e3)
+      // eslint-disable-next-line promise/catch-or-return
+      delay(100).then(() => tx.query('INSERT INTO test_tx ("desc") VALUES (\'leaked out\')')) // a bug-like case
+      .catch(e => t.ok(e)) // a bug-like case
+      await tx.query('SOMETHING WRONG')
+    }).catch(console.log)
+  }
+
+  await db.tx(async tx => {
+    await Promise.all([
+      runQueries(tx),
+      runSubTx(tx),
+    ])
+  })
+
+  const rows = await db.query('SELECT "desc" FROM test_tx')
+
+  t.deepEqual(rows, [
+    { desc: 'query 1' },
+    { desc: 'query 2' },
+    { desc: 'query 3' },
+    { desc: 'query 4' },
+    { desc: 'query 5' },
+  ])
+})

--- a/dev-docs/maping_with_resolvers.md
+++ b/dev-docs/maping_with_resolvers.md
@@ -21,7 +21,6 @@ const map = mapper({
 
 async function getAllUsers (includeProfiles = false) {
   return db.any('SELECT * FROM "user"')
-  .catch(error.db)
   .then(map.loading({
     contacts: {},
     profile: includeProfiles && {
@@ -93,8 +92,7 @@ const byBookIdResolver = createResolver(
     FROM "author" a
     JOIN "author_book_rel" r ON r.author_id = a.id
     WHERE r.book_id IN ($1:csv)
-  `, [bookIds])
-  .catch(error.db),
+  `, [bookIds]),
   // keyColumn still needed
   'book_id',
   { map, multi: true }

--- a/error.toml
+++ b/error.toml
@@ -11,6 +11,7 @@ read = 1000
 write = 1001
 delete = 1002
 internal = 1003
+query = 1004
 
 [user]
 password_wrong = 2001

--- a/migrate.js
+++ b/migrate.js
@@ -4,7 +4,7 @@ const argv = require('mri')(process.argv.slice(2), {
 })
 const migratio = require('migratio')
 
-const { db, sql, pgp } = require('db')
+const { pgpDB: db, sql, pgp } = require('db')
 
 const command = argv._[0]
 

--- a/package.json
+++ b/package.json
@@ -58,6 +58,6 @@
     "migrate": "NODE_PATH=. node -r ./env migrate.js",
     "start": "NODE_PATH=. node index.js",
     "test": "NODE_ENV=test run-s db:recreate db:seed test:run",
-    "test:run": "NODE_PATH=. tape -r ./env **/*.test.js | tap-difflet"
+    "test:run": "NODE_PATH=. tape -r ./env '{!(node_modules)/**/*.test.js,./*.test.js}' | tap-difflet"
   }
 }

--- a/repo/base.js
+++ b/repo/base.js
@@ -2,7 +2,6 @@ const _ = require('lodash')
 const assert = require('assert')
 
 const { db, pgp } = require('db')
-const error = require('error')
 
 const { format, csv } = pgp.as
 
@@ -66,7 +65,7 @@ function createResolver (getter, keyColumn, { map = _.identity, multi = false, c
   if (_.isString(getter)) {
     const leftPart = format('SELECT * FROM $1~ WHERE $2~ IN', [getter, keyColumn])
     const rightPart = condition ? `AND ${condition}` : ''
-    getter = (keys, { t = db }) => t.any(`${leftPart} (${csv(keys)}) ${rightPart}`).catch(error.db)
+    getter = (keys, { t = db }) => t.any(`${leftPart} (${csv(keys)}) ${rightPart}`)
   } else {
     assert(!condition, '"condition" option valid only with createResolver(tableName, ...)')
   }

--- a/repo/base.test.js
+++ b/repo/base.test.js
@@ -61,7 +61,7 @@ test('map.loading', async t => {
     c: ['id', cOfAResolver],
   })
 
-  const dbSpy = { ...db }
+  const dbSpy = Object.create(db)
   dbSpy.any = callCounter(db.any)
 
   const r = await db.any('SELECT * FROM "test_A"')

--- a/repo/passwordToken.js
+++ b/repo/passwordToken.js
@@ -12,7 +12,6 @@ async function create (userId) {
     VALUES ($1, $2)
     RETURNING token
   `, [userId, randomString({ length: 32 })])
-  .catch(error.db)
   return token
 }
 
@@ -27,7 +26,7 @@ async function createByEmail (email) {
 }
 
 async function remove (userId) {
-  return db.none('DELETE FROM password_token WHERE user_id = $1', [userId]).catch(error.db)
+  return db.none('DELETE FROM password_token WHERE user_id = $1', [userId])
 }
 
 async function get (token) {

--- a/repo/superadmin.js
+++ b/repo/superadmin.js
@@ -49,7 +49,6 @@ const getMany = (resource) => {
 const getAllCount = (resource) => {
   return async () => {
     return db.any('SELECT count(*) AS total FROM $1~', resource)
-    .catch(error.db)
   }
 }
 
@@ -69,7 +68,6 @@ const getById = (resource) => {
 const remove = (resource) => {
   return async (id) => {
     return db.none('DELETE FROM $1~ WHERE id = $2', [resource, id])
-    .catch(error.db)
   }
 }
 
@@ -77,7 +75,6 @@ const create = (resource) => {
   const { columnSet } = resourceMaps[resource]
   return async (data) => {
     return db.one(helper.insert(data, columnSet) + ' RETURNING id')
-    .catch(error.db)
   }
 }
 
@@ -85,7 +82,6 @@ const update = (resource) => {
   const { columnSet } = resourceMaps[resource]
   return async (id, data) => {
     return db.one(helper.update(data, columnSet) + ' WHERE id = $1 RETURNING id', id)
-    .catch(error.db)
   }
 }
 

--- a/repo/user.js
+++ b/repo/user.js
@@ -62,7 +62,6 @@ async function create (email, password) {
       id: user.id,
       role: konst.roleUser.none,
     })
-    .catch(error.db)
 
     return user
   })
@@ -74,7 +73,6 @@ async function updatePassword (id, password) {
     SET password = $2
     WHERE id = $1
   `, [id, await hashPassword(password)])
-  .catch(error.db)
 }
 
 async function updateEmail (id, email) {
@@ -129,7 +127,6 @@ async function getByEmailSilent (email) {
     FROM "user"
     WHERE email = $1
   `, [email])
-  .catch(error.db)
   .then(map)
 }
 
@@ -152,7 +149,6 @@ async function getRoleById (id) {
     FROM user_role
     WHERE user_id = $[id]
   `, { id })
-  .catch(error.db)
 
   return r ? r.role : konst.roleUser.none
 }

--- a/utils/data.js
+++ b/utils/data.js
@@ -1,0 +1,34 @@
+class Queue {
+  constructor () {
+    this._arr = []
+    this._i = 0
+    this.size = 0
+  }
+
+  push (value) {
+    this._arr.push(value)
+    ++this.size
+  }
+
+  shift () {
+    if (this.size === 0) return undefined
+
+    const value = this._arr[this._i]
+    this._arr[this._i] = undefined
+
+    if (++this._i > --this.size) {
+      this._arr = this._arr.slice(this._i)
+      this._i = 0
+    }
+
+    return value
+  }
+
+  peek () {
+    return this._arr[this._i]
+  }
+}
+
+module.exports = {
+  Queue,
+}

--- a/utils/pgp-wrappers.js
+++ b/utils/pgp-wrappers.js
@@ -1,0 +1,215 @@
+/**
+ * Database and Task classes to wrap respective PGP's ones
+ * with the main goal to make running queries and sub-transactions
+ * concurrently not broken. In particular, the Task class auto
+ * queues query/tx calls to ensure queries do not leak in and out
+ * of save-points.
+ * Additionally, wrappers provide query error customization
+ * via a `queryErrorHandler` option.
+ *
+ * NOTE: Wrappers do NOT replicate exactly PGP's API,
+ * leaving out some features/methods that we consider
+ * not important or even dangerous.
+ */
+const { as, queryResult } = require('pg-promise')
+
+const { Queue } = require('utils/data')
+
+const noop = () => {}
+
+function defaultQueryErrorHandler (err) {
+  throw err
+}
+
+function wrapDatabase (db, { queryErrorHandler = defaultQueryErrorHandler } = {}) {
+  return new Database(db, { queryErrorHandler })
+}
+
+class Database {
+  constructor (db, opts) {
+    this._t = db
+    this._opts = opts
+  }
+
+  wrapTask (t) {
+    return new Task(t, this._opts)
+  }
+
+  query (query, values, qrm = queryResult.any) {
+    return this._t.query(query, values, qrm).catch(this._opts.queryErrorHandler)
+  }
+
+  stream (qs, initCB) {
+    return this._t.stream(qs, initCB).catch(this._opts.queryErrorHandler)
+  }
+
+  tx (cb) {
+    return this._t.tx(t => new Task(t, this._opts).run(cb))
+  }
+
+  task (cb) {
+    return this._t.task(t => new Task(t, this._opts).run(cb))
+  }
+
+  none (query, values) {
+    return this.query(query, values, queryResult.none)
+  }
+
+  one (query, values) {
+    return this.query(query, values, queryResult.one)
+  }
+
+  oneOrNone (query, values) {
+    return this.query(query, values, queryResult.one | queryResult.none)
+  }
+
+  many (query, values) {
+    return this.query(query, values, queryResult.many)
+  }
+
+  manyOrNone (query, values) {
+    return this.query(query, values, queryResult.many | queryResult.none)
+  }
+
+  any (query, values) {
+    return this.query(query, values, queryResult.any)
+  }
+}
+
+class Task extends Database {
+  constructor (t, opts) {
+    super(t, opts)
+    this._queue = new Queue()
+    this._runningQueries = 0
+    this._runningTx = false
+    this._running = false
+    this._onAllDone = noop
+
+    this._next = () => {
+      if (!this._running && !this._runningQueries && !this._runningTx) {
+        this._onAllDone()
+        return
+      }
+
+      while (!this._runningTx && this._queue.size) {
+        if (this._runningQueries && this._queue.peek().method === this._runTx) {
+          break
+        }
+
+        const { resolve, method, args } = this._queue.shift()
+        resolve(method.apply(this, args))
+      }
+    }
+  }
+
+  _queueMethodCall (method, ...args) {
+    return new Promise(resolve => {
+      this._queue.push({ resolve, method, args })
+    })
+  }
+
+  async _runQuery (query, qrm) {
+    ++this._runningQueries
+    try {
+      return await this._t.query(query, undefined, qrm)
+    } catch (e) {
+      this._opts.queryErrorHandler(e)
+    } finally {
+      if (--this._runningQueries === 0) {
+        process.nextTick(this._next)
+      }
+    }
+  }
+
+  async _runQueryStream (qs, initCB) {
+    ++this._runningQueries
+    try {
+      return await this._t.stream(qs, initCB)
+    } catch (e) {
+      this._opts.queryErrorHandler(e)
+    } finally {
+      if (--this._runningQueries === 0) {
+        process.nextTick(this._next)
+      }
+    }
+  }
+
+  async _runTx (cb) {
+    this._runningTx = true
+    try {
+      return await this._t.tx(t => new Task(t, this._opts).run(cb))
+    } finally {
+      this._runningTx = false
+      process.nextTick(this._next)
+    }
+  }
+
+  query (query, values, qrm = queryResult.any) {
+    if (!this._running) {
+      throw new Error('running query on finished task/tx')
+    }
+    if (values != null) {
+      query = as.format(query, values)
+    }
+    if (this._runningTx) {
+      return this._queueMethodCall(this._runQuery, query, qrm)
+    }
+    return this._runQuery(query, qrm)
+  }
+
+  stream (qs, initCB) {
+    if (!this._running) {
+      throw new Error('running query stream on finished task/tx')
+    }
+    if (this._runningTx) {
+      return this._queueMethodCall(this._runQueryStream, qs, initCB)
+    }
+    return this._runQueryStream(qs, initCB)
+  }
+
+  tx (fn) {
+    if (!this._running) {
+      throw new Error('running tx on finished task/tx')
+    }
+    if (this._runningTx || this._runningQueries) {
+      return this._queueMethodCall(this._runTx, fn)
+    }
+    return this._runTx(fn)
+  }
+
+  // Already in a task (using same connection), so we can reuse the same one.
+  task (fn) {
+    // For consistency, we ensure fn is called in next microtask.
+    return Promise.resolve(this).then(fn)
+  }
+
+  async run (fn) {
+    if (this._running || !this._t) {
+      throw new Error('task can be ran only once')
+    }
+    this._running = true
+    try {
+      return await fn(this)
+    } finally {
+      const { level } = this._t.ctx
+      this._running = false
+      this._t = null
+
+      if (this._queue.size) {
+        const rejection = Promise.reject(new Error('task/tx aborted'))
+        while (this._queue.size) this._queue.shift().resolve(rejection)
+      }
+
+      // To ensure that queries are not leaked out, we wait for them to finish before the commit/rollback.
+      if (level > 0 && (this._runningQueries || this._runningTx)) {
+        await new Promise(resolve => {
+          this._onAllDone = resolve
+        })
+      }
+    }
+  }
+}
+
+module.exports = {
+  wrapDatabase,
+}

--- a/utils/promise.js
+++ b/utils/promise.js
@@ -1,0 +1,6 @@
+
+const delay = ms => new Promise(resolve => setTimeout(resolve, ms))
+
+module.exports = {
+  delay,
+}


### PR DESCRIPTION
By wrapping PGP's DB, we get:
 * Safe concurrent sub-transactions
 * Auto wrapping of DB errors (no need for `.catch(error.db)`)