### PR TITLE
loadBy*With => loadBy*

### DIFF
--- a/dev-docs/loaders.md
+++ b/dev-docs/loaders.md
@@ -46,8 +46,7 @@ async function list ({ limit = 10, includeUsers = false }) {
       userRepo.loadById(userId),
       userRepo.loadRolesByUserId(userId),
     ])
-    user.roles = roles
-    return user
+    return { ...user, roles }
   }
 
   return asyncMap(orders, order => {

--- a/dev-docs/loaders.md
+++ b/dev-docs/loaders.md
@@ -146,7 +146,7 @@ Now, not only we have certainty that login emails are unique using the index abo
 const loadByUserId = loader.all({
   select: `DISTINCT ON (id) p.*`,
   from: `"order" o, "product" p`,
-  where: `__ = o."user_id" AND p."order_id" = o."id"`,
+  where: `__::int = o."user_id" AND p."order_id" = o."id"`,
   orderBy: `"price" DESC`,
   map,
 })
@@ -161,11 +161,14 @@ const loadByUserId = loader.all({
   select: `DISTINCT ON (id) p.*`,
   from: `"order" o,
     JOIN "product" p ON p."order_id" = o."id"`,
-  where: `__ = o."user_id"`,
+  by: `o."user_id"`,
   orderBy: `"price" DESC`,
   map,
 })
+
 ```
+
+> NOTE: When using `__`, make sure to cast it to correct type (not necessary if type is`text`).
 
 ## Loaders from Custom Resolvers
 

--- a/repo/base.js
+++ b/repo/base.js
@@ -67,10 +67,14 @@ const sqlLoaderBuilder = ({ multi }) => ({
   map = identity,
   ...rest
 }) => {
+  assert(from, '"from" is required')
+  assert(!by || /^\w+$/.test(by), '"by", when given, should be a column name')
   assert(!by === /\b__\b/.test(where), '"by", xor use of `__` in "where", is required')
 
   if (/^\w+$/.test(from)) {
     from = as.name(from)
+  } else {
+    assert(!by, '"by" is used but "from" is not a simple table name - use `__` in "where" instead')
   }
 
   if (!by && select !== '*') {

--- a/repo/base.js
+++ b/repo/base.js
@@ -34,16 +34,16 @@ function mapper (mapping) {
   return map
 }
 
-function loader (resolveKeysWith, { db = _db, batchMaxSize = 1000, ...notAllowed } = {}) {
+function loader (resolveKeysWith, { db = _db, mapKey, batchMaxSize = 1000, ...notAllowed } = {}) {
   assert.deepEqual(notAllowed, {}, 'Invalid options')
-  const canLock = resolveKeysWith.length === 2
 
   const loaderWith = memoRefIn(new Map(), locking => {
     if (locking) {
-      assert(canLock, 'Loader not supporting locking')
+      assert(resolveKeysWith.length >= 2, 'Loader not supporting locking')
       assert(locking.startsWith('FOR '), 'Locking Clause expected to start with "FOR "')
     }
-    return memoRefIn(new WeakMap(), db => createLoader(resolveKeysWith(db, locking), { batchMaxSize }))
+    const options = { mapKey, batchMaxSize }
+    return memoRefIn(new WeakMap(), db => createLoader(resolveKeysWith(db, locking), options))
   })
 
   const loaderWithNoLocking = loaderWith('')

--- a/repo/base.js
+++ b/repo/base.js
@@ -58,20 +58,28 @@ function loader (resolveKeysWith, { db = _db, mapKey, batchMaxSize = 1000, ...no
 
 const asValue = x => as.csv([x])
 
-const sqlLoaderBuilder = ({ multi }) => ({ select = '*', from, by = '', where = '', orderBy = '', map = identity, ...rest }) => {
-  if (!!by === /\b__\b/.test(where)) {
-    assert(by, 'With no "by", you need to use "__" in "where"')
-    assert(!by, 'You can not use both "by" and "__" in "where"')
-  }
+const sqlLoaderBuilder = ({ multi }) => ({
+  select = '*',
+  from,
+  by = '',
+  where = '',
+  orderBy = '',
+  map = identity,
+  ...rest
+}) => {
+  assert(!by === /\b__\b/.test(where), '"by", xor use of `__` in "where", is required')
 
-  if (/\W/.test(from)) from = as.name(from)
-  const keyName = by || '__'
-  const keyColumn = as.name(keyName)
-  const mapItem = map[kMapItem] || map
+  if (/^\w+$/.test(from)) {
+    from = as.name(from)
+  }
 
   if (!by && select !== '*') {
     select = `__, ${select}`
   }
+
+  const keyName = by || '__'
+  const keyColumn = as.name(keyName)
+  const mapItem = map[kMapItem] || map
 
   return loader((db, locking) => async keys => {
     let r

--- a/repo/base.test.js
+++ b/repo/base.test.js
@@ -3,14 +3,14 @@ const { asyncMap } = require('utils/promise')
 const { mapper, loader } = require('./base')
 const { db } = require('db')
 
-test('loader', async t => {
+test.only('loader', async t => {
   await db.query(`
     CREATE TABLE test_loader (
       id int,
       group_num int
     );
     INSERT INTO test_loader (id, group_num) VALUES
-    (1, 1),
+    (1, 8),
     (2, 1),
     (3, 1),
     (4, 1),
@@ -57,7 +57,7 @@ test('loader', async t => {
     await promise4
 
     t.deepEqual(await asyncMap([1, 7, 3, 5], txLoadById), [
-      { id: 1, group: 1 },
+      { id: 1, group: 8 },
       { id: 7, group: 2 },
       { id: 3, group: 1 },
       { id: 5, group: 1 },
@@ -74,6 +74,35 @@ test('loader', async t => {
       ],
     ])
   })
+
+  {
+    const loadWithImplicitJoin = loader.one({
+      select: 'c.group_num AS "val"',
+      from: `test_loader a, test_loader b
+        JOIN test_loader c ON b.group_num = c.id
+      `,
+      where: '__::int = a.id AND a.group_num = b.id',
+      orderBy: '1',
+      map: r => r.val,
+    })
+
+    t.is(await loadWithImplicitJoin(2), 3)
+  }
+
+  {
+    const loadWithImplicitJoin = loader.one({
+      select: 'c.group_num AS "val"',
+      from: `test_loader a
+        JOIN test_loader b ON a.group_num = b.id
+        JOIN test_loader c ON b.group_num = c.id
+      `,
+      by: 'a.id',
+      orderBy: '1',
+      map: r => r.val,
+    })
+
+    t.is(await loadWithImplicitJoin(2), 3)
+  }
 
   await db.query('DROP TABLE test_loader')
 })

--- a/repo/base.test.js
+++ b/repo/base.test.js
@@ -25,34 +25,32 @@ test('loader', async t => {
     group: 'group_num',
   })
 
-  const loadByIdWith = loader.one({ from: 'test_loader', by: 'id', map })
-  const loadByGroupWith = loader.all({ from: 'test_loader', where: '-__ = -"group_num" AND "id" > 5', orderBy: '"id"', map })
+  const loadById = loader.one({ from: 'test_loader', by: 'id', map })
+  const loadByGroup = loader.all({ from: 'test_loader', where: '-__ = -"group_num" AND "id" > 5', orderBy: '"id"', map })
 
-  const loadById = loadByIdWith(db)
   const promise = loadById(8)
   t.ok(promise === Promise.resolve(promise), 'loader returns a promise')
   t.ok(promise === loadById(8), 'loader should cache by key')
-  t.ok(loadById === loadByIdWith(db), 'for same DB, loaderWith should return same loader')
+  t.ok(loadById === loadById.using(db), 'for same DB, loaderWith should return same loader')
   t.deepEqual(await promise, { id: 8, group: 3 })
   const promise2 = loadById(8)
   t.ok(promise !== promise2, 'after loading, it should not be cached any more')
 
-  const loadByGroup = loadByGroupWith(db)
-  t.ok(loadByGroup === loadByGroupWith(db), 'for same DB, loaderWith should return same loader')
+  t.ok(loadByGroup === loadByGroup.using(db), 'for same DB, loaderWith should return same loader')
   t.deepEqual(await loadByGroup(2), [
     { id: 6, group: 2 },
     { id: 7, group: 2 },
   ])
 
   await db.tx(async tx => {
-    const txLoadById = loadByIdWith(tx)
+    const txLoadById = loadById.using(tx)
 
     t.ok(txLoadById !== loadById, 'loaderWith for different t should return different loader')
 
     const promise3 = txLoadById(8)
     t.ok(promise3 !== promise2, 'loader cache should differ for different t')
-    t.ok(txLoadById === loadByIdWith(tx), 'for same tx, loaderWith should return same loader')
-    t.ok(txLoadById !== loadByIdWith.lockFor('UPDATE')(tx), 'for same tx, but different lock, loaderWith should return different loader')
+    t.ok(txLoadById === loadById.using(tx), 'for same tx, loaderWith should return same loader')
+    t.ok(txLoadById !== loadById.for('UPDATE').using(tx), 'for same tx, but different lock, loaderWith should return different loader')
     t.deepEqual(await promise3, { id: 8, group: 3 })
     const promise4 = txLoadById(8)
     t.ok(promise3 !== promise4, 'after loading, it should not be cached any more')
@@ -65,7 +63,7 @@ test('loader', async t => {
       { id: 5, group: 1 },
     ])
 
-    t.deepEqual(await asyncMap([1, 2, 3], loadByGroupWith(tx)), [
+    t.deepEqual(await asyncMap([1, 2, 3], loadByGroup.using(tx)), [
       [],
       [
         { id: 6, group: 2 },

--- a/repo/base.test.js
+++ b/repo/base.test.js
@@ -50,7 +50,7 @@ test('loader', async t => {
     const promise3 = txLoadById(8)
     t.ok(promise3 !== promise2, 'loader cache should differ for different t')
     t.ok(txLoadById === loadById.using(tx), 'for same tx, loaderWith should return same loader')
-    t.ok(txLoadById !== loadById.for('UPDATE').using(tx), 'for same tx, but different lock, loaderWith should return different loader')
+    t.ok(loadById.using(tx, 'FOR SHARE') !== loadById.using(tx, 'FOR UPDATE'), 'for same tx, but different lock, loaderWith should return different loader')
     t.deepEqual(await promise3, { id: 8, group: 3 })
     const promise4 = txLoadById(8)
     t.ok(promise3 !== promise4, 'after loading, it should not be cached any more')


### PR DESCRIPTION
Our loaders are still not well adopted, and I think the main reason could be the API.

```js
const loadByIdWith = loader.one({ from: 'user', by: 'id' })
//            ^^^^ WTF 

const user = await userRepo.loadByIdWith(db)(userId) // method hard to read
//                                  ^^^^^^^^ WTF
```

Motivation for such "strange" API was to make it less error prone, making it really hard to forget to pass `db`/`t`.

However passing `t` to functions is a larger issue that loaders alone are not resolving (for all other non-loader repo functions).

So, in an effort to come with an acceptable compromise that would make loaders being actually used, I first considered an API based on optional arguments.

```js
const loadById = loader.one({ from: 'user', by: 'id' })
//    ^^^^^^^^ nice

const user = await userRepo.loadById(userId) // nice and simple

const user = await userRepo.loadById(userId, t) // kinda nice

const users = await asyncMap(userIds, userRepo.loadById) // throws, index passed as second argument
const users = await asyncMap(userIds, id => userRepo.loadById(id)) // now works

```

First issue is that it's easy to miss that we passed (or not) the `t` making it less maintainable and error-prone.

Also, `loadById` could be a custom function that is not accepting the second argument (ignoring it). TS would mitigate this issue, but that's out of scope of this PR.

## New API

Instead of optional arguments, we can pass optional stuff with a `.using(...)` method.

```js
const loadById = loader.one({ from: 'user', by: 'id' }) // COOL

const user = await userRepo.loadById(userId) // nice, simple

const user = await userRepo.loadById.using(t)(userId) // I see it and I know `t` will not be ignored by `loadById`

const user = await userRepo.loadById.using(t, 'FOR UPDATE')(userId) // long, but still readable

const users = await asyncMap(userIds, userRepo.loadById) // works
const users = await asyncMap(userIds, userRepo.loadById.using(t, 'FOR UPDATE')) // works
```

Note that if a loader doesn't supports transactions, it will miss `.using(...)` and fail, preventing many silent bugs.
Similarly, if loader supports transactions but not locking, use of second argument will fail an internal check.

[Updated Loader docs](https://github.com/blazing-edge-labs/api-skeleton/blob/a6b76fabc382b3c457b34536c639f43105d21ce4/dev-docs/loaders.md)

Any thoughts?
